### PR TITLE
Feature: Update to 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CIS Kubernetes Benchmark - InSpec Profile
 
 ## Description
-This profile implements the [CIS Kubernetes 1.4.0 Benchmark](https://www.cisecurity.org/benchmark/kubernetes/).
+This profile implements the [CIS Kubernetes 1.4.1 Benchmark](https://www.cisecurity.org/benchmark/kubernetes/).
 
 ## Attributes
 

--- a/controls/1_1_master_node_api_server.rb
+++ b/controls/1_1_master_node_api_server.rb
@@ -180,9 +180,9 @@ control 'cis-kubernetes-benchmark-1.1.11' do
 end
 
 control 'cis-kubernetes-benchmark-1.1.12' do
-  title 'Ensure that the admission control plugin DenyEscalatingExec is set'
-  desc "Deny execution of `exec` and `attach` commands in privileged pods.\n\nRationale: Setting admission control policy to `DenyEscalatingExec` denies `exec` and `attach` commands to pods that run with escalated privileges that allow host access. This includes pods that run as privileged, have access to the host IPC namespace, and have access to the host PID namespace."
-  impact 1.0
+  title '[Deprecated] Ensure that the admission control plugin DenyEscalatingExec is set'
+  desc "[Deprecated] Deny execution of `exec` and `attach` commands in privileged pods.\n\nRationale: Setting admission control policy to `DenyEscalatingExec` denies `exec` and `attach` commands to pods that run with escalated privileges that allow host access. This includes pods that run as privileged, have access to the host IPC namespace, and have access to the host PID namespace."
+  impact 0.0
 
   tag cis: 'kubernetes:1.1.12'
   tag level: 1

--- a/controls/2_1_worker_node_kubelet.rb
+++ b/controls/2_1_worker_node_kubelet.rb
@@ -158,9 +158,9 @@ control 'cis-kubernetes-benchmark-2.1.10' do
 end
 
 control 'cis-kubernetes-benchmark-2.1.11' do
-  title 'Ensure that the --cadvisor-port argument is set to 0'
-  desc "Disable cAdvisor.\n\nRationale: cAdvisor provides potentially sensitive data and there's currently no way to block access to it using anything other than iptables. It does not require authentication/authorization to connect to the cAdvisor port. Hence, you should disable the port.\n**Note** The cAdvisor port setting was deprecated in Kubernetes v1.10 and will be removed in v1.12."
-  impact 1.0
+  title '[Deprecated] Ensure that the --cadvisor-port argument is set to 0'
+  desc "[Deprecated] Disable cAdvisor.\n\nRationale: cAdvisor provides potentially sensitive data and there's currently no way to block access to it using anything other than iptables. It does not require authentication/authorization to connect to the cAdvisor port. Hence, you should disable the port.\n**Note** The cAdvisor port setting was deprecated in Kubernetes v1.10 and will be removed in v1.12."
+  impact 0.0
 
   tag cis: 'kubernetes:2.1.11'
   tag level: 1


### PR DESCRIPTION
closes https://github.com/dev-sec/cis-kubernetes-benchmark/issues/23

The 1.4.1 release has 4 small changes listed in the PDF which I'll take below:
[CIS_Kubernetes_Benchmark_v1.4.1.pdf](https://github.com/dev-sec/cis-kubernetes-benchmark/files/3693970/CIS_Kubernetes_Benchmark_v1.4.1.pdf)


## Changes
| Date  | Version | Description |
| ------------- | ------------- | ------------- |
| 7/17/2019 | 1.4.1 | UPDATE -UPDATE - 2.1.11 [DEPRECATED] Ensure that the --cadvisor-port argument is set to 0 Ticket #8278 |
|7/17/2019 | 1.4.1 | UPDATE - 1.1.12 [DEPRECATED] Ensure that the admission control plugin DenyEscalatingExec is set Ticket #8712 |
| 7/17/2019 | 1.4.1 | UPDATE - Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers Ticket #8732 |
| 7/17/2019 | 1.4.1 | UPDATE - Ensure that the --experimental-encryption-providerconfig argument is set as appropriate Ticket #8697|

The first two are deprecations so, as such I've changed the title and description here and reduced the impact of both to 0. The last two do not seem to have had a functional change, perhaps it's a cleanup of the instructions(?). I don't have a copy of the 1.4.0 on hand but, I'll see if I can find it to verify the changes there (if anyone has one let me know!). 