### PR TITLE
Change static file references to inputs

### DIFF
--- a/controls/1_1_master_node_configuration_files.rb
+++ b/controls/1_1_master_node_configuration_files.rb
@@ -1,5 +1,15 @@
 title '1.1 Master Node: Configuration Files'
 
+apiserver_manifest = attribute('apiserver-manifest')
+controller_manager_manifest = attribute('controller_manager-manifest')
+scheduler_manifest = attribute('scheduler-manifest')
+etcd_manifest = attribute('etcd-manifest')
+etcd_regex = Regexp.new(attribute('etcd'))
+admin_conf = attribute('admin-conf')
+scheduler_conf = attribute('scheduler-conf')
+controller_manager_conf = attribute('controller_manager-conf')
+kubernetes_pki = attribute('kubernetes-pki')
+
 control 'cis-kubernetes-benchmark-1.1.1' do
   title 'Ensure that the API server pod specification file permissions are set to 644 or more restrictive'
   desc "Ensure that the API server pod specification file has permissions of `644` or more restrictive.\n\nRationale: The API server pod specification file controls various parameters that set the behavior of the API server. You should restrict its file permissions to maintain the integrity of the file. The file should be writable by only the administrators on the system."
@@ -9,10 +19,10 @@ control 'cis-kubernetes-benchmark-1.1.1' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/kube-apiserver.yaml').exist?
+    file(apiserver_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/kube-apiserver.yaml').mode.to_s(8) do
+  describe file(apiserver_manifest).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end
@@ -26,10 +36,10 @@ control 'cis-kubernetes-benchmark-1.1.2' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/kube-apiserver.yaml').exist?
+    file(apiserver_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/kube-apiserver.yaml') do
+  describe file(apiserver_manifest) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -44,10 +54,10 @@ control 'cis-kubernetes-benchmark-1.1.3' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/kube-controller-manager.yaml').exist?
+    file(controller_manager_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/kube-controller-manager.yaml').mode.to_s(8) do
+  describe file(controller_manager_manifest).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end
@@ -61,10 +71,10 @@ control 'cis-kubernetes-benchmark-1.1.4' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/kube-controller-manager.yaml').exist?
+    file(controller_manager_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/kube-controller-manager.yaml') do
+  describe file(controller_manager_manifest) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -79,10 +89,10 @@ control 'cis-kubernetes-benchmark-1.1.5' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/kube-scheduler.yaml').exist?
+    file(scheduler_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/kube-scheduler.yaml').mode.to_s(8) do
+  describe file(scheduler_manifest).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end
@@ -96,10 +106,10 @@ control 'cis-kubernetes-benchmark-1.1.6' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/kube-scheduler.yaml').exist?
+    file(scheduler_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/kube-scheduler.yaml') do
+  describe file(scheduler_manifest) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -114,10 +124,10 @@ control 'cis-kubernetes-benchmark-1.1.7' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/etcd.yaml').exist?
+    file(etcd_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/etcd.yaml').mode.to_s(8) do
+  describe file(etcd_manifest).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end
@@ -131,10 +141,10 @@ control 'cis-kubernetes-benchmark-1.1.8' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/manifests/etcd.yaml').exist?
+    file(etcd_manifest).exist?
   end
 
-  describe file('/etc/kubernetes/manifests/etcd.yaml') do
+  describe file(etcd_manifest) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -223,7 +233,7 @@ control 'cis-kubernetes-benchmark-1.1.12' do
   tag cis: 'kubernetes:1.1.12'
   tag level: 1
 
-  etcd_process = processes(Regexp.new(%r{/usr/bin/etcd}))
+  etcd_process = processes(etcd_regex)
   data_dir = ''
 
   catch(:stop) do
@@ -260,10 +270,10 @@ control 'cis-kubernetes-benchmark-1.1.13' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/admin.conf').exist?
+    file(admin_conf).exist?
   end
 
-  describe file('/etc/kubernetes/admin.conf').mode.to_s(8) do
+  describe file(admin_conf).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end
@@ -277,10 +287,10 @@ control 'cis-kubernetes-benchmark-1.1.14' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/admin.conf').exist?
+    file(admin_conf).exist?
   end
 
-  describe file('/etc/kubernetes/admin.conf') do
+  describe file(admin_conf) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -295,10 +305,10 @@ control 'cis-kubernetes-benchmark-1.1.15' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/scheduler.conf').exist?
+    file(scheduler_conf).exist?
   end
 
-  describe file('/etc/kubernetes/scheduler.conf').mode.to_s(8) do
+  describe file(scheduler_conf).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end
@@ -312,10 +322,10 @@ control 'cis-kubernetes-benchmark-1.1.16' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/scheduler.conf').exist?
+    file(scheduler_conf).exist?
   end
 
-  describe file('/etc/kubernetes/scheduler.conf') do
+  describe file(scheduler_conf) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -330,10 +340,10 @@ control 'cis-kubernetes-benchmark-1.1.17' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/controller-manager.conf').exist?
+    file(controller_manager_conf).exist?
   end
 
-  describe file('/etc/kubernetes/controller-manager.conf').mode.to_s(8) do
+  describe file(controller_manager_conf).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end
@@ -347,10 +357,10 @@ control 'cis-kubernetes-benchmark-1.1.18' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/controller-manager.conf').exist?
+    file(controller_manager_conf).exist?
   end
 
-  describe file('/etc/kubernetes/controller-manager.conf') do
+  describe file(controller_manager_conf) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -365,10 +375,10 @@ control 'cis-kubernetes-benchmark-1.1.19' do
   tag level: 1
 
   only_if do
-    directory('/etc/kubernetes/pki').exist?
+    directory(kubernetes_pki).exist?
   end
 
-  describe directory('/etc/kubernetes/pki') do
+  describe directory(kubernetes_pki) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -383,7 +393,7 @@ control 'cis-kubernetes-benchmark-1.1.20' do
   tag level: 1
 
   only_if do
-    directory('/etc/kubernetes/pki').exist?
+    directory(kubernetes_pki).exist?
   end
 
   cert_files = command('find /etc/kubernetes/pki -type f -name *.crt').stdout.split
@@ -409,7 +419,7 @@ control 'cis-kubernetes-benchmark-1.1.21' do
   tag level: 1
 
   only_if do
-    directory('/etc/kubernetes/pki').exist?
+    directory(kubernetes_pki).exist?
   end
 
   key_files = command('find /etc/kubernetes/pki -type f -name *.key').stdout.split

--- a/controls/2_etcd_node.rb
+++ b/controls/2_etcd_node.rb
@@ -1,6 +1,6 @@
 title '2 Etcd Node'
 
-etcd_regex = Regexp.new(%r{/usr/bin/etcd})
+etcd_regex = Regexp.new(attribute('etcd'))
 etcd_process = processes(etcd_regex)
 etcd_env_vars = process_env_var(etcd_regex)
 

--- a/controls/4_1_worker_node_configuration_files.rb
+++ b/controls/4_1_worker_node_configuration_files.rb
@@ -3,6 +3,7 @@ title '4.1.1 Worker Node: Configuration Files'
 kubelet = attribute('kubelet')
 # fallback if kubelet attribute is not defined
 kubelet = kubernetes.kubelet_bin if kubelet.empty?
+kubelet_conf = attribute('kubelet-conf')
 
 only_if('kubelet not found') do
   processes(kubelet).exists?
@@ -36,10 +37,10 @@ control 'cis-kubernetes-benchmark-4.1.2' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/kubelet.conf').exist?
+    file(kubelet_conf).exist?
   end
 
-  describe file('/etc/kubernetes/kubelet.conf') do
+  describe file(kubelet_conf) do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -109,10 +110,10 @@ control 'cis-kubernetes-benchmark-4.1.5' do
   tag level: 1
 
   only_if do
-    file('/etc/kubernetes/kubelet.conf').exist?
+    file(kubelet_conf).exist?
   end
 
-  describe file('/etc/kubernetes/kubelet.conf').mode.to_s(8) do
+  describe file(kubelet_conf).mode.to_s(8) do
     it { should match(/[0246][024][024]/) }
   end
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -13,21 +13,75 @@ attributes:
   - name: cis_level
     required: false
     description: 'CIS profile level to audit'
-    default: 2
+    value: 2
     type: numeric
   - name: apiserver
     required: false
     description: 'The name of the apiserver process'
     type: string
+    value: kube-apiserver
+  - name: apiserver-manifest
+    require: false
+    description: 'The path of the apiserver manifest'
+    type: string
+    value: '/etc/kubernetes/manifests/kube-apiserver.yaml'
   - name: controller_manager
     required: false
     description: 'The name of the controller manager process'
     type: string
+    value: kube-controller-manager
+  - name: controller_manager-conf
+    require: false
+    description: 'The path of the controller-manager.conf file'
+    type: string
+    value: '/etc/kubernetes/controller-manager.conf'
+  - name: controller_manager-manifest
+    require: false
+    description: 'The path of the controller manager manifest'
+    type: string
+    value: '/etc/kubernetes/manifests/kube-controller-manager.yaml'
   - name: scheduler
     required: false
     description: 'The name of the kube scheduler proces'
     type: string
+    value: kube-scheduler
+  - name: scheduler-conf
+    require: false
+    description: 'The path of the scheduler.conf file'
+    type: string
+    value: '/etc/kubernetes/scheduler.conf'
+  - name: scheduler-manifest
+    require: false
+    description: 'The path of the kube scheduler manifest'
+    type: string
+    value: '/etc/kubernetes/manifests/kube-scheduler.yaml'
   - name: kubelet
     required: false
     description: 'The name of the kubelet process'
     type: string
+    value: kubelet
+  - name: kubelet-conf
+    require: false
+    description: 'The path of the kubelet.conf file'
+    type: string
+    value: '/etc/kubernetes/kubelet.conf'
+  - name: etcd
+    required: false
+    description: 'The name of the etcd process'
+    type: string
+    value: /usr/bin/etcd
+  - name: etcd-manifest
+    require: false
+    description: 'The path of the etcd manifest'
+    type: string
+    value: '/etc/kubernetes/manifests/etcd.yaml'
+  - name: admin-conf
+    require: false
+    description: 'The path of the admin.conf file'
+    type: string
+    value: '/etc/kubernetes/admin.conf'
+  - name: kubernetes-pki
+    require: false
+    description: 'The path of the Kubernetes PKI directory'
+    type: string
+    value: '/etc/kubernetes/pki'


### PR DESCRIPTION
When assessing a cluster which was set up using KOPS, I noticed that all configuration files had hardcoded values which did not fit this environemtn. In addition, the name of the `etcd` process was hardcoded as well.

With this PR, I propose to change those into inputs, which have the same default value as in the code before. 

I also switched from `default:` to `value:` for the inputs to get rid of deprecation warnings.
